### PR TITLE
Show Payment Details on Success page even if session is reset.

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -162,6 +162,8 @@ class Extension extends AbstractPluginIntegration {
 	 * @return string
 	 */
 	public static function redirect_url( $url, $payment ) {
+		$source_id = (int) $payment->get_source_id();
+
 		switch ( $payment->get_status() ) {
 			case Core_Statuses::CANCELLED:
 			case Core_Statuses::EXPIRED:
@@ -169,7 +171,7 @@ class Extension extends AbstractPluginIntegration {
 				return EasyDigitalDownloads::get_option_page_url( 'failure_page' );
 
 			case Core_Statuses::SUCCESS:
-				return EasyDigitalDownloads::get_option_page_url( 'success_page' );
+				return add_query_arg( 'payment_key', edd_get_payment_key( $source_id ), edd_get_success_page_uri() );
 
 			case Core_Statuses::RESERVED:
 			case Core_Statuses::OPEN:


### PR DESCRIPTION
In several cases, the session gets reset before the custom reaches the success page. Due to which the customer sees the error message "Sorry, trouble retrieving payment receipt." If we pass the payment_key parameter in the success URL, the customer will see correct information even if the session is reset.
Also, while showing the success page from the session, EDD always shows the payment status of the last payment, even if we want to show the payment status of the old payment.

https://github.com/easydigitaldownloads/easy-digital-downloads/blob/f97f4f6f5454921a2014dc1fa8f4caa5f550108c/includes/shortcodes.php#L682-L694